### PR TITLE
UI streamlining updates to the Settings Page (alert preferences form)

### DIFF
--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -187,6 +187,10 @@ const AlertSettings = () => {
             <Typography variant="h4" paddingBottom={'10px'}>
               Alert Preferences
             </Typography>
+            {/* Disclaimer and Beta Alert */}
+            <Typography variant="body2" color="textSecondary" marginBottom={'15px'}> 
+            Note: Email and in-app alert functionalities are currently under development.
+            </Typography>
             <form onSubmit={handleSubmit}>
               {/* Current Preferences Section */}
               <Paper


### PR DESCRIPTION
Quick updates:
- Integrate current preferences into the main preferences box, eliminating the separate box on the left side. Now it's just shown above the checkboxes in just one line for easy reference.
- Update checkboxes accordingly, ensuring they are checked if the current preferences are so.
- Clean up code and add comments for Material UI.
- Add edge cases for email and Slack URL inputs to handle invalid entries, preventing users from entering emails or URLs that are way too long and invalid.